### PR TITLE
Fix typo in ``RenderFormSet.render``.

### DIFF
--- a/src/components/RenderFormSet.jsx
+++ b/src/components/RenderFormSet.jsx
@@ -107,7 +107,7 @@ var RenderFormSet = React.createClass({
       />}
       {formset.forms().map(form => <RenderForm
         form={form}
-        formComponent={props.formComponent}
+        component={props.formComponent}
         progress={props.progress}
         row={props.row}
         rowComponent={props.rowComponent}


### PR DESCRIPTION
When mapping a new RenderForm to each formset's form, the RenderFormSet's formComponent prop was being assigned to RenderForm's formComponent instead of component.
